### PR TITLE
Reposiciona portfólio para frontend + crm, com tags de projeto específicas

### DIFF
--- a/astro-redesign/src/components/Hero.astro
+++ b/astro-redesign/src/components/Hero.astro
@@ -17,12 +17,12 @@ const t = useTranslations(lang as any);
 const toolkit = [
   { icon: 'simple-icons:astro', brand: 'Astro', color: '#BC52EE' },
   { icon: 'simple-icons:react', brand: 'React', color: '#61DAFB', iconClass: 'scale-[0.96]' },
-  { icon: 'simple-icons:tailwindcss', brand: 'Tailwind', color: '#38BDF8', iconClass: 'scale-[1.05]' },
-  { icon: 'simple-icons:figma', brand: 'Figma', color: '#F24E1E', iconClass: 'scale-[0.95]' },
   { icon: 'simple-icons:typescript', brand: 'TypeScript', color: '#3178C6' },
-  { icon: 'simple-icons:supabase', brand: 'Supabase', color: '#3ECF8E', iconClass: 'scale-[0.96]' },
+  { icon: 'simple-icons:tailwindcss', brand: 'Tailwind', color: '#38BDF8', iconClass: 'scale-[1.05]' },
   { icon: 'simple-icons:hubspot', brand: 'HubSpot', color: '#FF7A59', iconClass: 'scale-[0.93]' },
+  { icon: 'simple-icons:supabase', brand: 'Supabase', color: '#3ECF8E', iconClass: 'scale-[0.96]' },
   { icon: 'simple-icons:wordpress', brand: 'WordPress', title: 'WordPress + Elementor', color: '#21759B', iconClass: 'scale-[0.9]' },
+  { icon: 'simple-icons:figma', brand: 'Figma', color: '#F24E1E', iconClass: 'scale-[0.95]' },
   { icon: 'simple-icons:framer', brand: 'Framer', color: '#0055FF', iconClass: 'scale-[0.88]' },
 ];
 

--- a/astro-redesign/src/data/projects.ts
+++ b/astro-redesign/src/data/projects.ts
@@ -32,7 +32,7 @@ const projectContent: Record<ProjectSlug, ProjectContent> = {
     subtitle: 'registro diário minimalista e seguro.',
     overview: 'um espaço focado em privacidade e fluidez para anotações do dia a dia. a ideia principal foi criar um diário digital sem distrações visuais.',
     challengeAndSolution: 'o maior foco foi garantir a privacidade de quem escreve. o app utiliza criptografia local para assegurar que as notas sejam lidas apenas pelo próprio usuário, unindo uma interface extremamente limpa com uma arquitetura segura por baixo dos panos.',
-    role: ['ui design', 'frontend'],
+    role: ['product design', 'frontend', 'arquitetura de dados'],
     stack: [
       'typescript',
       'vite',
@@ -58,7 +58,7 @@ const projectContent: Record<ProjectSlug, ProjectContent> = {
     subtitle: 'rádio, arquivo e identidade visual.',
     overview: 'o hub central para o programa de rádio coisas bonitas. um espaço para reunir os mixes, as entrevistas e as colaborações musicais transmitidas na hkcr.',
     challengeAndSolution: 'o desafio aqui foi traduzir a atmosfera sonora do projeto para o navegador. desenvolvi uma identidade visual interativa que funciona não apenas como um portfólio de áudio, mas como uma extensão imersiva da experiência da rádio.',
-    role: ['visual design', 'frontend', 'curadoria'],
+    role: ['identidade visual', 'frontend', 'curadoria'],
     stack: ['html', 'css', 'javascript'],
     links: [
       {
@@ -80,7 +80,7 @@ const projectContent: Record<ProjectSlug, ProjectContent> = {
     subtitle: 'processamento de imagens em real-time.',
     overview: 'uma ferramenta web experimental focada em aplicar algoritmos de dithering em imagens direto no navegador.',
     challengeAndSolution: 'o objetivo foi criar uma interface responsiva que permitisse o ajuste fino dos parâmetros do filtro visual com feedback imediato. o projeto une exploração estética com manipulação eficiente de canvas no front-end.',
-    role: ['ui design', 'desenvolvimento web'],
+    role: ['creative coding', 'canvas & shaders', 'frontend'],
     stack: ['svelte', 'canvas api'],
   },
   'ambi-mixer': {
@@ -88,7 +88,7 @@ const projectContent: Record<ProjectSlug, ProjectContent> = {
     subtitle: 'gerador de ambiências para foco.',
     overview: 'um web app desenhado para ajudar na concentração, combinando diferentes texturas sonoras para criar a atmosfera perfeita para trabalhar ou estudar.',
     challengeAndSolution: 'atualmente em desenvolvimento, o foco está na criação de uma interface limpa onde a manipulação dos canais de áudio seja tátil e intuitiva, rodando de forma leve em segundo plano.',
-    role: ['ui design', 'frontend'],
+    role: ['frontend', 'web audio api', 'design de interação'],
     stack: ['svelte', 'web audio api'],
     links: [
       {

--- a/astro-redesign/src/i18n/ui.ts
+++ b/astro-redesign/src/i18n/ui.ts
@@ -8,19 +8,19 @@ export const defaultLang = 'pt';
 export const ui = {
   pt: {
     // --- NAV & HERO ---
-    'role.title': 'designer + frontend',
-    'meta.title': 'vitor hugo cunha | designer + frontend',
-    'meta.description': 'portfólio de vitor hugo cunha, com foco em interfaces, frontend e projetos autorais.',
+    'role.title': 'frontend + crm',
+    'meta.title': 'vitor hugo cunha | frontend + crm',
+    'meta.description': 'portfólio de vitor hugo cunha, com foco em frontend, automação de crm e projetos autorais.',
     'nav.home': 'início',
     'nav.about': 'sobre',
     'nav.projects': 'projetos',
     'nav.aria.language': 'selecionar idioma',
     'nav.aria.theme': 'alternar tema',
-    'hero.role': 'designer + frontend',
+    'hero.role': 'frontend + crm',
     'hero.kicker': 'portfólio 2026',
-    'hero.title.primary': 'designer +',
-    'hero.title.secondary': 'frontend.',
-    'hero.desc': 'desenho e desenvolvo interfaces simples, com atenção aos detalhes e implementação limpa.',
+    'hero.title.primary': 'frontend +',
+    'hero.title.secondary': 'crm.',
+    'hero.desc': 'desenvolvo interfaces e automações, com atenção aos detalhes e implementação limpa.',
     'hero.swipe': 'arraste',
     
     // --- PROJECTS ---
@@ -35,11 +35,11 @@ export const ui = {
     'work.status': 'disponível para projetos e parcerias',
     'work.statusShort': 'disponível',
     'work.title': 'falar comigo ->',
-    'work.desc': 'se tiver um freela, posso ajudar com design de interface (ui) e frontend.',
+    'work.desc': 'se tiver um freela, posso ajudar com frontend, automação de crm e web design.',
 
     // --- ABOUT ---
-    'about.intro.1': 'sou vitor hugo. desenho e desenvolvo interfaces digitais entre o figma e o front-end.',
-    'about.intro.2': 'atualmente trabalho na camerge aplicando ui/ux, código e dados. cuido de páginas de conversão, sistemas internos e regras de negócio no crm.',
+    'about.intro.1': 'sou vitor hugo. trabalho entre frontend e automação de marketing, unindo código e crm.',
+    'about.intro.2': 'atualmente na camerge cuido de automações no hubspot, tráfego pago e páginas de conversão. comecei em design de interface, e ainda é uma área que amo — só que aos poucos venho migrando mais pro código e pros dados.',
     'about.intro.3': 'no tempo livre, fico entre música, games e teclados mecânicos.',
     'about.highlights.ui.title': 'interface',
     'about.highlights.ui.desc': 'hierarquia limpa, tipografia bem resolvida e ritmo sem excesso.',
@@ -144,19 +144,19 @@ export const ui = {
   
   en: {
     // --- NAV & HERO ---
-    'role.title': 'designer + frontend',
-    'meta.title': 'vitor hugo cunha | designer + frontend',
-    'meta.description': 'portfolio of vitor hugo cunha, focused on interfaces, frontend, and personal projects.',
+    'role.title': 'frontend + crm',
+    'meta.title': 'vitor hugo cunha | frontend + crm',
+    'meta.description': 'portfolio of vitor hugo cunha, focused on frontend, crm automation, and personal projects.',
     'nav.home': 'home',
     'nav.about': 'about',
     'nav.projects': 'projects',
     'nav.aria.language': 'select language',
     'nav.aria.theme': 'toggle theme',
-    'hero.role': 'designer + frontend',
+    'hero.role': 'frontend + crm',
     'hero.kicker': 'portfolio 2026',
-    'hero.title.primary': 'designer +',
-    'hero.title.secondary': 'frontend.',
-    'hero.desc': 'i design and build simple interfaces, with attention to detail and clean implementation.',
+    'hero.title.primary': 'frontend +',
+    'hero.title.secondary': 'crm.',
+    'hero.desc': 'i build interfaces and automations, with attention to detail and clean implementation.',
     'hero.swipe': 'swipe',
     
     // --- PROJECTS ---
@@ -173,12 +173,12 @@ export const ui = {
     'work.status': 'open to projects & collaborations',
     'work.statusShort': 'available',
     'work.title': 'talk to me ->',
-    'work.desc': 'if you have a freelance gig, i can help with ui design and frontend.',
+    'work.desc': 'if you have a freelance gig, i can help with frontend, crm automation, and web design.',
     
     // --- ABOUT ---
-    'about.intro.1': "i'm vitor. i work as a design engineer, blending ui/ux, frontend, and data.",
-    'about.intro.2': 'i design interfaces focused on conversion and performance, caring for the flow end-to-end—from crm structure to code in the browser.',
-    'about.intro.3': 'currently focused on digital products and business intelligence at camerge.',
+    'about.intro.1': "i'm vitor. i work between frontend and marketing automation, blending code and crm.",
+    'about.intro.2': "at camerge, i handle hubspot automations, paid traffic, and conversion pages. i started out in interface design—still love it—but i've been steadily moving more into code and data.",
+    'about.intro.3': "in my free time, i'm usually between music, games, and mechanical keyboards.",
     'about.highlights.ui.title': 'interface',
     'about.highlights.ui.desc': 'clean hierarchy, well-resolved type, and rhythm without excess.',
     'about.highlights.frontend.title': 'frontend',
@@ -292,18 +292,18 @@ export const ui = {
 
   jp: {
     // Mantendo placeholders para evitar erros
-    'role.title': 'デザイン + フロントエンド',
-    'meta.title': 'vitor hugo cunha | デザイン + フロントエンド',
-    'meta.description': 'vitor hugo cunha のポートフォリオ。インターフェース、フロントエンド、個人プロジェクト。',
+    'role.title': 'フロントエンド + CRM',
+    'meta.title': 'vitor hugo cunha | フロントエンド + CRM',
+    'meta.description': 'vitor hugo cunha のポートフォリオ。フロントエンド、CRM自動化、個人プロジェクト。',
     'nav.home': 'ホーム',
     'nav.about': '約',
     'nav.projects': 'プロジェクト',
     'nav.aria.language': '言語を選択',
     'nav.aria.theme': 'テーマを切り替え',
-    'hero.role': 'デザイン + フロントエンド',
+    'hero.role': 'フロントエンド + CRM',
     'hero.kicker': 'ポートフォリオ 2026',
-    'hero.title.primary': 'デザイン +',
-    'hero.title.secondary': 'フロントエンド.',
+    'hero.title.primary': 'フロントエンド +',
+    'hero.title.secondary': 'CRM.',
     'hero.desc': '細部にまでこだわった流動的なインターフェースの作成に注力しています。',
     'hero.swipe': 'スワイプ',
     'riji.tag': '毎日のミニマル日記 · 2026',


### PR DESCRIPTION
## Summary
- Muda o tagline principal (hero, meta title, título da aba) de "designer + frontend" para "frontend + crm", refletindo o direcionamento atual pra desenvolvimento e automação de marketing.
- Atualiza o texto do "sobre" (pt e en) pra liderar com frontend + automação, mencionando o design de interface como ponto de partida que ainda é querido, mas que vem perdendo espaço pro código/dados no dia a dia.
- Reordena o toolkit no Hero, priorizando HubSpot/Supabase/WordPress sobre Figma.
- Troca as tags de "papel" de cada projeto (antes quase todas "ui design" + "frontend") por descrições específicas do trabalho real em cada um: `product design / frontend / arquitetura de dados` (riji), `identidade visual / frontend / curadoria` (coisas bonitas), `creative coding / canvas & shaders / frontend` (dither studio), `frontend / web audio api / design de interação` (ambi mixer).

## Test plan
- [x] `npm run build` em `astro-redesign/` concluído sem erros.
- [x] Conferido no HTML gerado (pt e en) o novo tagline e as tags de papel por projeto.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCySEAQ9aZXcBm4JVzoKS2)_