### PR TITLE
Traduz páginas de projeto para inglês

### DIFF
--- a/astro-redesign/src/components/Hero.astro
+++ b/astro-redesign/src/components/Hero.astro
@@ -2,7 +2,7 @@
 // ...existing code...
 
 import { useTranslations } from '../i18n/utils';
-import { projectEntries } from '../data/projects';
+import { getProjectEntries } from '../data/projects';
 import BentoGrid from './bento/BentoGrid.astro';
 import BentoItem from './bento/BentoItem.astro';
 import { Icon } from 'astro-icon/components';
@@ -26,15 +26,17 @@ const toolkit = [
   { icon: 'simple-icons:framer', brand: 'Framer', color: '#0055FF', iconClass: 'scale-[0.88]' },
 ];
 
-const featuredProjectData = projectEntries.find((project) => project.slug === 'riji');
+const projectHref = (slug: string) => (lang === 'pt' ? `/projects/${slug}` : `/${lang}/projects/${slug}`);
+
+const featuredProjectData = getProjectEntries(lang as any).find((project) => project.slug === 'riji');
 const featuredProject = featuredProjectData
   ? {
-      href: `/projects/${featuredProjectData.slug}`,
+      href: projectHref(featuredProjectData.slug),
       title: featuredProjectData.title,
       desc: featuredProjectData.subtitle,
     }
   : {
-      href: '/projects/riji',
+      href: projectHref('riji'),
       title: '日记 riji',
       desc: t('projects.riji.desc'),
     };

--- a/astro-redesign/src/components/ProjectDetail.astro
+++ b/astro-redesign/src/components/ProjectDetail.astro
@@ -1,0 +1,136 @@
+---
+import Layout from '../layouts/Layout.astro';
+import { useTranslations } from '../i18n/utils';
+import type { ProjectEntry, ProjectLang } from '../data/projects';
+
+interface Props {
+  lang: ProjectLang;
+  project: ProjectEntry;
+}
+
+const { lang, project } = Astro.props;
+const t = useTranslations(lang as any);
+const htmlLang = lang === 'pt' ? 'pt-br' : 'en';
+const backHref = lang === 'pt' ? '/#projects' : `/${lang}#projects`;
+
+const pageTitle = `${project.title} | vitor hugo cunha`;
+const description = project.overview;
+---
+
+<Layout title={pageTitle} description={description} lang={htmlLang}>
+  <main class="min-h-screen pt-24 md:pt-28 pb-20 px-6 md:px-12">
+    <div class="w-full max-w-[1100px] mx-auto space-y-16">
+      <header class="space-y-8">
+        <button
+          type="button"
+          id="back-button"
+          aria-label={t('project.back.aria')}
+          data-back-href={backHref}
+          class="group inline-flex items-center gap-2 rounded-full border border-brand-dark/10 dark:border-brand-light/10 bg-brand-dark/[0.035] dark:bg-brand-light/[0.055] px-4 py-2.5 text-xs font-mono tracking-widest text-brand-dark/65 dark:text-brand-light/70 shadow-[0_14px_36px_-28px_rgba(39,35,42,0.55)] transition-all duration-300 hover:-translate-x-0.5 hover:border-brand-purple/45 hover:bg-brand-purple/10 hover:text-brand-purple dark:hover:bg-brand-purple/15 relative z-10 pointer-events-auto"
+        >
+          <span aria-hidden="true" class="text-sm leading-none transition-transform duration-300 group-hover:-translate-x-1">←</span>
+          <span class="relative">
+            {t('project.back')}
+            <span class="absolute -bottom-1 left-0 h-px w-0 bg-brand-purple/70 transition-all duration-300 group-hover:w-full"></span>
+          </span>
+        </button>
+
+        <div class="space-y-4">
+          <span class="text-[11px] font-mono tracking-[0.3em] text-brand-purple">{t('project.eyebrow')}</span>
+          <h1 class="font-display font-bold text-4xl md:text-6xl text-brand-dark dark:text-brand-light tracking-tight leading-[0.96]">
+            {project.title}
+          </h1>
+          <p class="text-base md:text-lg text-brand-dark/65 dark:text-brand-light/65 max-w-[48ch]">
+            {project.subtitle}
+          </p>
+        </div>
+
+        {project.resolvedImage ? (
+          <figure class="rounded-[2rem] overflow-hidden border border-black/8 dark:border-white/10 bg-black/[0.04] dark:bg-white/5">
+            <img
+              src={project.resolvedImage}
+              alt={project.imageAlt}
+              class={`w-full h-full object-cover ${project.slug === 'riji' ? '' : 'object-left'}`}
+              loading="lazy"
+            />
+          </figure>
+        ) : null}
+      </header>
+
+      <section class="grid grid-cols-1 md:grid-cols-12 gap-10 md:gap-14">
+        <div class="md:col-span-7 space-y-10">
+          <div class="space-y-3">
+            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">{t('project.overview.title')}</h2>
+            <p class="text-lg leading-relaxed text-brand-dark/80 dark:text-brand-light/80">
+              {project.overview}
+            </p>
+          </div>
+
+          <div class="space-y-3">
+            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">{t('project.challenge.title')}</h2>
+            <p class="text-base leading-relaxed text-brand-dark/70 dark:text-brand-light/70">
+              {project.challengeAndSolution}
+            </p>
+          </div>
+        </div>
+
+        <aside class="md:col-span-5 space-y-10">
+          {project.links && project.links.length > 0 ? (
+            <div class="space-y-3">
+              <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">{t('project.links.title')}</h2>
+              <div class="flex flex-col gap-2">
+                {project.links.map((link) => (
+                  <a
+                    href={link.href}
+                    target="_blank"
+                    rel="noreferrer"
+                    class="group inline-flex items-center justify-between gap-4 rounded-2xl border border-brand-dark/10 dark:border-brand-light/10 bg-black/[0.035] dark:bg-white/[0.055] px-4 py-3 text-sm font-medium text-brand-dark/75 dark:text-brand-light/75 transition-all duration-300 hover:-translate-y-0.5 hover:border-brand-purple/35 hover:bg-brand-purple/10 hover:text-brand-purple"
+                  >
+                    <span>{link.label}</span>
+                    <span aria-hidden="true" class="text-base leading-none transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5">↗</span>
+                  </a>
+                ))}
+              </div>
+            </div>
+          ) : null}
+
+          <div class="space-y-3">
+            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">{t('project.role.title')}</h2>
+            <div class="flex flex-wrap gap-2">
+              {project.role.map((item) => (
+                <span class="inline-flex text-[11px] font-mono tracking-wider text-brand-dark/60 dark:text-brand-light/60 bg-black/[0.04] dark:bg-white/5 px-2.5 py-1 rounded-lg">
+                  {item}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div class="space-y-3">
+            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">{t('project.stack.title')}</h2>
+            <div class="flex flex-wrap gap-2">
+              {project.stack.map((item) => (
+                <span class="inline-flex text-[11px] font-mono tracking-wider text-brand-dark/60 dark:text-brand-light/60 bg-black/[0.04] dark:bg-white/5 px-2.5 py-1 rounded-lg">
+                  {item}
+                </span>
+              ))}
+            </div>
+          </div>
+        </aside>
+      </section>
+    </div>
+  </main>
+  <script is:inline>
+    const attachBackButton = () => {
+      const backButton = document.getElementById('back-button');
+      if (!backButton || backButton.dataset.bound === 'true') return;
+      backButton.dataset.bound = 'true';
+
+      backButton.addEventListener('click', () => {
+        window.location.assign(backButton.dataset.backHref || '/#projects');
+      });
+    };
+
+    attachBackButton();
+    document.addEventListener('astro:page-load', attachBackButton);
+  </script>
+</Layout>

--- a/astro-redesign/src/components/Projects.astro
+++ b/astro-redesign/src/components/Projects.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon } from 'astro-icon/components';
 import { useTranslations } from '../i18n/utils';
-import { projectEntries, ProjectStatus } from '../data/projects';
+import { getProjectEntries, ProjectStatus } from '../data/projects';
 
 interface Props {
   lang: string;
@@ -10,7 +10,8 @@ interface Props {
 const { lang } = Astro.props;
 const t = useTranslations(lang as any);
 
-const projects = projectEntries;
+const projects = getProjectEntries(lang as any);
+const projectHref = (slug: string) => (lang === 'pt' ? `/projects/${slug}` : `/${lang}/projects/${slug}`);
 
 const statusConfig: Record<ProjectStatus, { label: string; class: string }> = {
   'live': { label: t('projects.status.live'), class: 'bg-green-500/20 text-green-600 dark:text-green-400' },
@@ -46,7 +47,7 @@ const MOBILE_TAG_LIMIT = 2;
     <div class="flex gap-4 snap-x snap-mandatory pb-2">
       {projects.map((project) => (
         <a
-          href={`/projects/${project.slug}`}
+          href={projectHref(project.slug)}
           data-astro-prefetch="viewport"
           aria-label={`${t('projects.details')}: ${project.title}`}
           class="project-card group snap-start shrink-0 w-[82vw] max-w-[340px] rounded-[2rem] surface overflow-hidden text-left"
@@ -109,7 +110,7 @@ const MOBILE_TAG_LIMIT = 2;
   <div class="hidden md:grid grid-cols-1 md:grid-cols-2 gap-6">
     {projects.map((project, index) => (
       <a 
-        href={`/projects/${project.slug}`}
+        href={projectHref(project.slug)}
         data-astro-prefetch="viewport"
         aria-label={`${t('projects.details')}: ${project.title}`}
         class={`project-card group relative p-0 rounded-3xl surface text-left overflow-hidden reveal reveal-delay-${(index + 1) * 100} cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple/50 md:min-h-[240px] motion-reduce:transform-none motion-reduce:transition-none`}

--- a/astro-redesign/src/data/projects.ts
+++ b/astro-redesign/src/data/projects.ts
@@ -1,5 +1,11 @@
 export type ProjectStatus = 'live' | 'in-progress' | 'planned';
 export type ProjectSlug = 'riji' | 'coisas-bonitas' | 'dither-studio' | 'ambi-mixer';
+export type ProjectLang = 'pt' | 'en';
+
+export interface ProjectLink {
+  label: string;
+  href: string;
+}
 
 export interface ProjectContent {
   title: string;
@@ -7,13 +13,8 @@ export interface ProjectContent {
   overview: string;
   challengeAndSolution: string;
   role: string[];
-  stack: string[];
+  imageAlt: string;
   links?: ProjectLink[];
-}
-
-export interface ProjectLink {
-  label: string;
-  href: string;
 }
 
 export interface ProjectEntry extends ProjectContent {
@@ -22,17 +23,147 @@ export interface ProjectEntry extends ProjectContent {
   color: 'purple' | 'terracotta' | 'green';
   image: string;
   fallbackImage: string;
-  imageAlt: string;
+  stack: string[];
   resolvedImage: string | null;
 }
 
-const projectContent: Record<ProjectSlug, ProjectContent> = {
-  riji: {
-    title: '日记 riji',
-    subtitle: 'registro diário minimalista e seguro.',
-    overview: 'um espaço focado em privacidade e fluidez para anotações do dia a dia. a ideia principal foi criar um diário digital sem distrações visuais.',
-    challengeAndSolution: 'o maior foco foi garantir a privacidade de quem escreve. o app utiliza criptografia local para assegurar que as notas sejam lidas apenas pelo próprio usuário, unindo uma interface extremamente limpa com uma arquitetura segura por baixo dos panos.',
-    role: ['product design', 'frontend', 'arquitetura de dados'],
+const projectContent: Record<ProjectLang, Record<ProjectSlug, ProjectContent>> = {
+  pt: {
+    riji: {
+      title: '日记 riji',
+      subtitle: 'registro diário minimalista e seguro.',
+      overview: 'um espaço focado em privacidade e fluidez para anotações do dia a dia. a ideia principal foi criar um diário digital sem distrações visuais.',
+      challengeAndSolution: 'o maior foco foi garantir a privacidade de quem escreve. o app utiliza criptografia local para assegurar que as notas sejam lidas apenas pelo próprio usuário, unindo uma interface extremamente limpa com uma arquitetura segura por baixo dos panos.',
+      role: ['product design', 'frontend', 'arquitetura de dados'],
+      imageAlt: 'captura da interface do riji',
+      links: [
+        {
+          label: 'abrir site',
+          href: 'https://rijiapp.site/',
+        },
+      ],
+    },
+    'coisas-bonitas': {
+      title: 'coisas bonitas',
+      subtitle: 'rádio, arquivo e identidade visual.',
+      overview: 'o hub central para o programa de rádio coisas bonitas. um espaço para reunir os mixes, as entrevistas e as colaborações musicais transmitidas na hkcr.',
+      challengeAndSolution: 'o desafio aqui foi traduzir a atmosfera sonora do projeto para o navegador. desenvolvi uma identidade visual interativa que funciona não apenas como um portfólio de áudio, mas como uma extensão imersiva da experiência da rádio.',
+      role: ['identidade visual', 'frontend', 'curadoria'],
+      imageAlt: 'captura do site coisas bonitas',
+      links: [
+        {
+          label: 'site',
+          href: 'https://coisasbonitas.neocities.org/',
+        },
+        {
+          label: 'residência na hkcr.live',
+          href: 'https://hkcr.live/residents/coisas-bonitas',
+        },
+        {
+          label: 'soundcloud',
+          href: 'https://soundcloud.com/coisasbonitas',
+        },
+      ],
+    },
+    'dither-studio': {
+      title: 'dither studio',
+      subtitle: 'processamento de imagens em real-time.',
+      overview: 'uma ferramenta web experimental focada em aplicar algoritmos de dithering em imagens direto no navegador.',
+      challengeAndSolution: 'o objetivo foi criar uma interface responsiva que permitisse o ajuste fino dos parâmetros do filtro visual com feedback imediato. o projeto une exploração estética com manipulação eficiente de canvas no front-end.',
+      role: ['creative coding', 'canvas & shaders', 'frontend'],
+      imageAlt: 'captura do dither studio',
+    },
+    'ambi-mixer': {
+      title: 'ambi mixer',
+      subtitle: 'gerador de ambiências para foco.',
+      overview: 'um web app desenhado para ajudar na concentração, combinando diferentes texturas sonoras para criar a atmosfera perfeita para trabalhar ou estudar.',
+      challengeAndSolution: 'atualmente em desenvolvimento, o foco está na criação de uma interface limpa onde a manipulação dos canais de áudio seja tátil e intuitiva, rodando de forma leve em segundo plano.',
+      role: ['frontend', 'web audio api', 'design de interação'],
+      imageAlt: 'captura do ambi mixer em funcionamento',
+      links: [
+        {
+          label: 'abrir app',
+          href: 'https://ambi-mixer.vercel.app/',
+        },
+      ],
+    },
+  },
+  en: {
+    riji: {
+      title: '日记 riji',
+      subtitle: 'a minimal, private daily journal.',
+      overview: 'a space focused on privacy and flow for everyday writing. the core idea was building a digital journal without visual distractions.',
+      challengeAndSolution: "the main focus was protecting the writer's privacy. the app uses local encryption so entries can only be read by their author, pairing an extremely clean interface with a secure architecture underneath.",
+      role: ['product design', 'frontend', 'data architecture'],
+      imageAlt: 'screenshot of the riji interface',
+      links: [
+        {
+          label: 'open site',
+          href: 'https://rijiapp.site/',
+        },
+      ],
+    },
+    'coisas-bonitas': {
+      title: 'coisas bonitas',
+      subtitle: 'radio, archive, and visual identity.',
+      overview: 'the central hub for the coisas bonitas radio show. a space to gather the mixes, interviews, and musical collaborations broadcast on hkcr.',
+      challengeAndSolution: "the challenge was translating the project's sonic atmosphere to the browser. i built an interactive visual identity that works not just as an audio portfolio, but as an immersive extension of the radio experience.",
+      role: ['visual identity', 'frontend', 'curation'],
+      imageAlt: 'screenshot of the coisas bonitas site',
+      links: [
+        {
+          label: 'site',
+          href: 'https://coisasbonitas.neocities.org/',
+        },
+        {
+          label: 'hkcr.live residency',
+          href: 'https://hkcr.live/residents/coisas-bonitas',
+        },
+        {
+          label: 'soundcloud',
+          href: 'https://soundcloud.com/coisasbonitas',
+        },
+      ],
+    },
+    'dither-studio': {
+      title: 'dither studio',
+      subtitle: 'real-time image processing.',
+      overview: 'an experimental web tool focused on applying dithering algorithms to images directly in the browser.',
+      challengeAndSolution: "the goal was a responsive interface for fine-tuning the visual filter's parameters with immediate feedback. the project blends aesthetic exploration with efficient canvas manipulation on the frontend.",
+      role: ['creative coding', 'canvas & shaders', 'frontend'],
+      imageAlt: 'screenshot of dither studio',
+    },
+    'ambi-mixer': {
+      title: 'ambi mixer',
+      subtitle: 'an ambience generator for focus.',
+      overview: 'a web app designed to help with concentration, blending different sound textures to create the perfect atmosphere for work or study.',
+      challengeAndSolution: "currently in development, the focus is a clean interface where mixing audio channels feels tactile and intuitive, running lightly in the background.",
+      role: ['frontend', 'web audio api', 'interaction design'],
+      imageAlt: 'screenshot of ambi mixer in action',
+      links: [
+        {
+          label: 'open app',
+          href: 'https://ambi-mixer.vercel.app/',
+        },
+      ],
+    },
+  },
+};
+
+const baseProjects: Array<{
+  slug: ProjectSlug;
+  status: ProjectStatus;
+  color: 'purple' | 'terracotta' | 'green';
+  image: string;
+  fallbackImage: string;
+  stack: string[];
+}> = [
+  {
+    slug: 'riji',
+    status: 'in-progress',
+    color: 'purple',
+    image: '/projects/riji-thumb.webp',
+    fallbackImage: '/projects/riji-placeholder.svg',
     stack: [
       'typescript',
       'vite',
@@ -46,67 +177,6 @@ const projectContent: Record<ProjectSlug, ProjectContent> = {
       'jszip',
       'vercel',
     ],
-    links: [
-      {
-        label: 'abrir site',
-        href: 'https://rijiapp.site/',
-      },
-    ],
-  },
-  'coisas-bonitas': {
-    title: 'coisas bonitas',
-    subtitle: 'rádio, arquivo e identidade visual.',
-    overview: 'o hub central para o programa de rádio coisas bonitas. um espaço para reunir os mixes, as entrevistas e as colaborações musicais transmitidas na hkcr.',
-    challengeAndSolution: 'o desafio aqui foi traduzir a atmosfera sonora do projeto para o navegador. desenvolvi uma identidade visual interativa que funciona não apenas como um portfólio de áudio, mas como uma extensão imersiva da experiência da rádio.',
-    role: ['identidade visual', 'frontend', 'curadoria'],
-    stack: ['html', 'css', 'javascript'],
-    links: [
-      {
-        label: 'site',
-        href: 'https://coisasbonitas.neocities.org/',
-      },
-      {
-        label: 'residência na hkcr.live',
-        href: 'https://hkcr.live/residents/coisas-bonitas',
-      },
-      {
-        label: 'soundcloud',
-        href: 'https://soundcloud.com/coisasbonitas',
-      },
-    ],
-  },
-  'dither-studio': {
-    title: 'dither studio',
-    subtitle: 'processamento de imagens em real-time.',
-    overview: 'uma ferramenta web experimental focada em aplicar algoritmos de dithering em imagens direto no navegador.',
-    challengeAndSolution: 'o objetivo foi criar uma interface responsiva que permitisse o ajuste fino dos parâmetros do filtro visual com feedback imediato. o projeto une exploração estética com manipulação eficiente de canvas no front-end.',
-    role: ['creative coding', 'canvas & shaders', 'frontend'],
-    stack: ['svelte', 'canvas api'],
-  },
-  'ambi-mixer': {
-    title: 'ambi mixer',
-    subtitle: 'gerador de ambiências para foco.',
-    overview: 'um web app desenhado para ajudar na concentração, combinando diferentes texturas sonoras para criar a atmosfera perfeita para trabalhar ou estudar.',
-    challengeAndSolution: 'atualmente em desenvolvimento, o foco está na criação de uma interface limpa onde a manipulação dos canais de áudio seja tátil e intuitiva, rodando de forma leve em segundo plano.',
-    role: ['frontend', 'web audio api', 'design de interação'],
-    stack: ['svelte', 'web audio api'],
-    links: [
-      {
-        label: 'abrir app',
-        href: 'https://ambi-mixer.vercel.app/',
-      },
-    ],
-  },
-};
-
-const baseProjects: Array<Omit<ProjectEntry, keyof ProjectContent | 'resolvedImage'>> = [
-  {
-    slug: 'riji',
-    status: 'in-progress',
-    color: 'purple',
-    image: '/projects/riji-thumb.webp',
-    fallbackImage: '/projects/riji-placeholder.svg',
-    imageAlt: 'captura da interface do riji',
   },
   {
     slug: 'coisas-bonitas',
@@ -114,7 +184,7 @@ const baseProjects: Array<Omit<ProjectEntry, keyof ProjectContent | 'resolvedIma
     color: 'terracotta',
     image: '/projects/coisas-bonitas-thumb.webp',
     fallbackImage: '/projects/coisas-bonitas-placeholder.svg',
-    imageAlt: 'captura do site coisas bonitas',
+    stack: ['html', 'css', 'javascript'],
   },
   {
     slug: 'ambi-mixer',
@@ -122,7 +192,7 @@ const baseProjects: Array<Omit<ProjectEntry, keyof ProjectContent | 'resolvedIma
     color: 'terracotta',
     image: '/projects/ambi-mixer-thumb.webp',
     fallbackImage: '/projects/ambi-studio-placeholder.svg',
-    imageAlt: 'captura do ambi mixer em funcionamento',
+    stack: ['svelte', 'web audio api'],
   },
   {
     slug: 'dither-studio',
@@ -130,16 +200,19 @@ const baseProjects: Array<Omit<ProjectEntry, keyof ProjectContent | 'resolvedIma
     color: 'purple',
     image: '/projects/dither-studio-thumb.webp',
     fallbackImage: '/projects/dither-studio-placeholder.svg',
-    imageAlt: 'captura do dither studio',
+    stack: ['svelte', 'canvas api'],
   },
 ];
 
-export const projectEntries: ProjectEntry[] = baseProjects.map((project) => ({
-  ...project,
-  ...projectContent[project.slug],
-  resolvedImage: project.image,
-}));
+export function getProjectEntries(lang: ProjectLang = 'pt'): ProjectEntry[] {
+  const content = projectContent[lang] ?? projectContent.pt;
+  return baseProjects.map((project) => ({
+    ...project,
+    ...(content[project.slug] ?? projectContent.pt[project.slug]),
+    resolvedImage: project.image,
+  }));
+}
 
-export function getProjectBySlug(slug: string): ProjectEntry | undefined {
-  return projectEntries.find((project) => project.slug === slug);
+export function getProjectBySlug(slug: string, lang: ProjectLang = 'pt'): ProjectEntry | undefined {
+  return getProjectEntries(lang).find((project) => project.slug === slug);
 }

--- a/astro-redesign/src/i18n/ui.ts
+++ b/astro-redesign/src/i18n/ui.ts
@@ -113,7 +113,17 @@ export const ui = {
     'projects.dither.modal.intro': 'dither studio é uma ferramenta para testar processamento de imagem com dithering em wasm.',
     'projects.dither.linkLabel': 'abrir dither studio',
     'github.label': 'github',
-    
+
+    // --- PROJECT DETAIL PAGE ---
+    'project.back': 'voltar',
+    'project.back.aria': 'voltar para a página anterior',
+    'project.eyebrow': 'projeto',
+    'project.overview.title': 'visão geral',
+    'project.challenge.title': 'desafio e solução',
+    'project.links.title': 'links',
+    'project.role.title': 'papel',
+    'project.stack.title': 'stack',
+
     // --- EXPERIÊNCIA ---
     'exp.title': 'experiência',
     'exp.path': 'trajetória',
@@ -251,6 +261,16 @@ export const ui = {
     'projects.dither.modal.intro': 'image processing with dithering algorithms in wasm.',
     'projects.dither.linkLabel': 'open dither studio',
     'github.label': 'github',
+
+    // --- PROJECT DETAIL PAGE ---
+    'project.back': 'back',
+    'project.back.aria': 'back to the previous page',
+    'project.eyebrow': 'project',
+    'project.overview.title': 'overview',
+    'project.challenge.title': 'challenge & solution',
+    'project.links.title': 'links',
+    'project.role.title': 'role',
+    'project.stack.title': 'stack',
 
     // --- EXPERIENCE (UPDATED) ---
     'exp.title': 'experience',

--- a/astro-redesign/src/pages/[lang]/projects/[slug].astro
+++ b/astro-redesign/src/pages/[lang]/projects/[slug].astro
@@ -1,0 +1,19 @@
+---
+import ProjectDetail from '../../../components/ProjectDetail.astro';
+import { getProjectEntries, getProjectBySlug } from '../../../data/projects';
+
+export async function getStaticPaths() {
+  return getProjectEntries('en').map((project) => ({
+    params: { lang: 'en', slug: project.slug },
+  }));
+}
+
+const { slug } = Astro.params;
+const project = getProjectBySlug(slug, 'en');
+
+if (!project) {
+  throw new Error(`project not found: ${slug}`);
+}
+---
+
+<ProjectDetail lang="en" project={project} />

--- a/astro-redesign/src/pages/projects/[slug].astro
+++ b/astro-redesign/src/pages/projects/[slug].astro
@@ -1,137 +1,19 @@
 ---
-import Layout from '../../layouts/Layout.astro';
-import { getProjectBySlug, projectEntries } from '../../data/projects';
+import ProjectDetail from '../../components/ProjectDetail.astro';
+import { getProjectEntries, getProjectBySlug } from '../../data/projects';
 
 export async function getStaticPaths() {
-  return projectEntries.map((project) => ({
+  return getProjectEntries('pt').map((project) => ({
     params: { slug: project.slug },
   }));
 }
 
 const { slug } = Astro.params;
-const project = getProjectBySlug(slug);
+const project = getProjectBySlug(slug, 'pt');
 
 if (!project) {
   throw new Error(`projeto não encontrado: ${slug}`);
 }
-
-const pageTitle = `${project.title} | vitor hugo cunha`;
-const description = project.overview;
 ---
 
-<Layout title={pageTitle} description={description} lang="pt-br">
-  <main class="min-h-screen pt-24 md:pt-28 pb-20 px-6 md:px-12">
-    <div class="w-full max-w-[1100px] mx-auto space-y-16">
-      <header class="space-y-8">
-        <button
-          type="button"
-          id="back-button"
-          aria-label="voltar para a página anterior"
-          class="group inline-flex items-center gap-2 rounded-full border border-brand-dark/10 dark:border-brand-light/10 bg-brand-dark/[0.035] dark:bg-brand-light/[0.055] px-4 py-2.5 text-xs font-mono tracking-widest text-brand-dark/65 dark:text-brand-light/70 shadow-[0_14px_36px_-28px_rgba(39,35,42,0.55)] transition-all duration-300 hover:-translate-x-0.5 hover:border-brand-purple/45 hover:bg-brand-purple/10 hover:text-brand-purple dark:hover:bg-brand-purple/15 relative z-10 pointer-events-auto"
-        >
-          <span aria-hidden="true" class="text-sm leading-none transition-transform duration-300 group-hover:-translate-x-1">←</span>
-          <span class="relative">
-            voltar
-            <span class="absolute -bottom-1 left-0 h-px w-0 bg-brand-purple/70 transition-all duration-300 group-hover:w-full"></span>
-          </span>
-        </button>
-
-        <div class="space-y-4">
-          <span class="text-[11px] font-mono tracking-[0.3em] text-brand-purple">projeto</span>
-          <h1 class="font-display font-bold text-4xl md:text-6xl text-brand-dark dark:text-brand-light tracking-tight leading-[0.96]">
-            {project.title}
-          </h1>
-          <p class="text-base md:text-lg text-brand-dark/65 dark:text-brand-light/65 max-w-[48ch]">
-            {project.subtitle}
-          </p>
-        </div>
-
-        {project.resolvedImage ? (
-          <figure class="rounded-[2rem] overflow-hidden border border-black/8 dark:border-white/10 bg-black/[0.04] dark:bg-white/5">
-            <img
-              src={project.resolvedImage}
-              alt={project.imageAlt}
-              class={`w-full h-full object-cover ${project.slug === 'riji' ? '' : 'object-left'}`}
-              loading="lazy"
-            />
-          </figure>
-        ) : null}
-      </header>
-
-      <section class="grid grid-cols-1 md:grid-cols-12 gap-10 md:gap-14">
-        <div class="md:col-span-7 space-y-10">
-          <div class="space-y-3">
-            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">visão geral</h2>
-            <p class="text-lg leading-relaxed text-brand-dark/80 dark:text-brand-light/80">
-              {project.overview}
-            </p>
-          </div>
-
-          <div class="space-y-3">
-            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">desafio e solução</h2>
-            <p class="text-base leading-relaxed text-brand-dark/70 dark:text-brand-light/70">
-              {project.challengeAndSolution}
-            </p>
-          </div>
-        </div>
-
-        <aside class="md:col-span-5 space-y-10">
-          {project.links && project.links.length > 0 ? (
-            <div class="space-y-3">
-              <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">links</h2>
-              <div class="flex flex-col gap-2">
-                {project.links.map((link) => (
-                  <a
-                    href={link.href}
-                    target="_blank"
-                    rel="noreferrer"
-                    class="group inline-flex items-center justify-between gap-4 rounded-2xl border border-brand-dark/10 dark:border-brand-light/10 bg-black/[0.035] dark:bg-white/[0.055] px-4 py-3 text-sm font-medium text-brand-dark/75 dark:text-brand-light/75 transition-all duration-300 hover:-translate-y-0.5 hover:border-brand-purple/35 hover:bg-brand-purple/10 hover:text-brand-purple"
-                  >
-                    <span>{link.label}</span>
-                    <span aria-hidden="true" class="text-base leading-none transition-transform duration-300 group-hover:-translate-y-0.5 group-hover:translate-x-0.5">↗</span>
-                  </a>
-                ))}
-              </div>
-            </div>
-          ) : null}
-
-          <div class="space-y-3">
-            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">papel</h2>
-            <div class="flex flex-wrap gap-2">
-              {project.role.map((item) => (
-                <span class="inline-flex text-[11px] font-mono tracking-wider text-brand-dark/60 dark:text-brand-light/60 bg-black/[0.04] dark:bg-white/5 px-2.5 py-1 rounded-lg">
-                  {item}
-                </span>
-              ))}
-            </div>
-          </div>
-
-          <div class="space-y-3">
-            <h2 class="text-xs font-mono tracking-widest text-brand-dark/40 dark:text-brand-light/40">stack</h2>
-            <div class="flex flex-wrap gap-2">
-              {project.stack.map((item) => (
-                <span class="inline-flex text-[11px] font-mono tracking-wider text-brand-dark/60 dark:text-brand-light/60 bg-black/[0.04] dark:bg-white/5 px-2.5 py-1 rounded-lg">
-                  {item}
-                </span>
-              ))}
-            </div>
-          </div>
-        </aside>
-      </section>
-    </div>
-  </main>
-  <script is:inline>
-    const attachBackButton = () => {
-      const backButton = document.getElementById('back-button');
-      if (!backButton || backButton.dataset.bound === 'true') return;
-      backButton.dataset.bound = 'true';
-
-      backButton.addEventListener('click', () => {
-        window.location.assign('/#projects');
-      });
-    };
-
-    attachBackButton();
-    document.addEventListener('astro:page-load', attachBackButton);
-  </script>
-</Layout>
+<ProjectDetail lang="pt" project={project} />


### PR DESCRIPTION
## Summary
- `data/projects.ts` agora guarda o conteúdo de cada projeto (título, subtítulo, overview, desafio/solução, papel, alt da imagem, links) por idioma (pt/en), via `getProjectEntries(lang)` / `getProjectBySlug(slug, lang)`. Stack e metadados de imagem continuam compartilhados entre idiomas.
- Extraído o template da página de detalhe pra um componente `ProjectDetail.astro`, reutilizado por `/projects/:slug` (pt) e pela nova rota `/en/projects/:slug` (en).
- Os textos fixos da página de detalhe (voltar, projeto, visão geral, desafio e solução, links, papel, stack) agora vêm do `i18n/ui.ts`, traduzidos em pt/en.
- Os links dos cards de projeto (home e hero) passam a apontar para a rota correta por idioma (`/projects/:slug` em pt, `/en/projects/:slug` em en), e o botão "voltar" da página de detalhe volta para `/#projects` ou `/en#projects` conforme o idioma.

## Test plan
- [x] `npm run build` em `astro-redesign/` concluído sem erros, gerando as 4 rotas `/en/projects/*` além das pt.
- [x] Conferido no HTML gerado que `/en/projects/riji` mostra todo o conteúdo em inglês (overview, challenge & solution, role, labels) e que os cards em `/en` linkam para `/en/projects/...`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCySEAQ9aZXcBm4JVzoKS2)_