### PR TITLE
Corrige contraste do texto do "sobre" no tema claro

### DIFF
--- a/astro-redesign/src/components/About.astro
+++ b/astro-redesign/src/components/About.astro
@@ -66,13 +66,13 @@ const avatarAlt = 'retrato de vitor hugo cunha';
       
       <!-- Intro -->
       <div class="space-y-6 max-w-xl reveal reveal-delay-200">
-        <p class="text-xl md:text-2xl leading-relaxed text-white font-semibold">
+        <p class="text-xl md:text-2xl leading-relaxed text-brand-dark dark:text-brand-light font-semibold">
           {t('about.intro.1')}
         </p>
-        <p class="text-base md:text-lg leading-relaxed text-zinc-400">
+        <p class="text-base md:text-lg leading-relaxed text-brand-dark/65 dark:text-brand-light/65">
           {t('about.intro.2')}
         </p>
-        <p class="text-base md:text-lg leading-relaxed text-zinc-400">
+        <p class="text-base md:text-lg leading-relaxed text-brand-dark/65 dark:text-brand-light/65">
           {t('about.intro.3')}
         </p>
       </div>


### PR DESCRIPTION
## Summary
- O bloco de introdução da seção "sobre" (`About.astro`) usava `text-white` e `text-zinc-400` fixos, sem variante `dark:`. No tema escuro passava despercebido (próximo o suficiente do branco/cinza esperado), mas no tema claro o texto ficava quase invisível contra o fundo claro — como no print reportado.
- Troquei pelas classes usadas no resto do site: `text-brand-dark dark:text-brand-light` para a linha em destaque e `text-brand-dark/65 dark:text-brand-light/65` para as linhas secundárias (mesmo padrão do `work.desc` no Hero).

## Test plan
- [x] `npm run build` em `astro-redesign/` concluído sem erros.
- [x] Conferido no HTML gerado que as classes corretas foram aplicadas nas três linhas do "sobre".

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCySEAQ9aZXcBm4JVzoKS2)_